### PR TITLE
Fixed 'no such overload' error

### DIFF
--- a/frida-scripts/fingerprint-bypass.js
+++ b/frida-scripts/fingerprint-bypass.js
@@ -35,7 +35,11 @@ function getAuthResult(resultObj, cryptoInst) {
             var authenticationResultInst = resultObj.$new(cryptoInst, null);
         }
         catch (error) {
-            var authenticationResultInst = resultObj.$new(cryptoInst);
+            try {
+                var authenticationResultInst = resultObj.$new(cryptoInst);
+            } catch (error) {
+                var authenticationResultInst = resultObj.$new(null, null, 0, false);
+            }
         }
     }
     console.log("cryptoInst:, " + cryptoInst + " class: " + cryptoInst.$className);


### PR DESCRIPTION
I was unable to use the one bypass script in an application, the added changes allowed me to bypass fingerprint authentication. 

Would someone else be able to verify that the script still works on their device? 